### PR TITLE
hostapd: enable CTRL_IFACE_MIB for hostapd-full

### DIFF
--- a/package/network/services/hostapd/files/hostapd-basic.config
+++ b/package/network/services/hostapd/files/hostapd-basic.config
@@ -394,3 +394,8 @@ CONFIG_TLS=internal
 # Services can connect to the bus and provide methods
 # that can be called by other services or clients.
 CONFIG_UBUS=y
+
+# OpenWrt patch 380-disable-ctrl-iface-mib.patch
+# leads to the MIB only being compiled in if
+# CONFIG_CTRL_IFACE_MIB is enabled.
+#CONFIG_CTRL_IFACE_MIB=y

--- a/package/network/services/hostapd/files/hostapd-full.config
+++ b/package/network/services/hostapd/files/hostapd-full.config
@@ -394,3 +394,8 @@ CONFIG_TAXONOMY=y
 # Services can connect to the bus and provide methods
 # that can be called by other services or clients.
 CONFIG_UBUS=y
+
+# OpenWrt patch 380-disable-ctrl-iface-mib.patch
+# leads to the MIB only being compiled in if
+# CONFIG_CTRL_IFACE_MIB is enabled.
+CONFIG_CTRL_IFACE_MIB=y

--- a/package/network/services/hostapd/files/hostapd-mini.config
+++ b/package/network/services/hostapd/files/hostapd-mini.config
@@ -394,3 +394,8 @@ CONFIG_TLS=internal
 # Services can connect to the bus and provide methods
 # that can be called by other services or clients.
 CONFIG_UBUS=y
+
+# OpenWrt patch 380-disable-ctrl-iface-mib.patch
+# leads to the MIB only being compiled in if
+# CONFIG_CTRL_IFACE_MIB is enabled.
+#CONFIG_CTRL_IFACE_MIB=y

--- a/package/network/services/hostapd/files/wpa_supplicant-basic.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-basic.config
@@ -618,3 +618,8 @@ CONFIG_GETRANDOM=y
 # Services can connect to the bus and provide methods
 # that can be called by other services or clients.
 CONFIG_UBUS=y
+
+# OpenWrt patch 380-disable-ctrl-iface-mib.patch
+# leads to the MIB only being compiled in if
+# CONFIG_CTRL_IFACE_MIB is enabled.
+#CONFIG_CTRL_IFACE_MIB=y

--- a/package/network/services/hostapd/files/wpa_supplicant-full.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-full.config
@@ -618,3 +618,8 @@ CONFIG_IBSS_RSN=y
 # Services can connect to the bus and provide methods
 # that can be called by other services or clients.
 CONFIG_UBUS=y
+
+# OpenWrt patch 380-disable-ctrl-iface-mib.patch
+# leads to the MIB only being compiled in if
+# CONFIG_CTRL_IFACE_MIB is enabled.
+CONFIG_CTRL_IFACE_MIB=y

--- a/package/network/services/hostapd/files/wpa_supplicant-mini.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-mini.config
@@ -618,3 +618,8 @@ CONFIG_GETRANDOM=y
 # Services can connect to the bus and provide methods
 # that can be called by other services or clients.
 CONFIG_UBUS=y
+
+# OpenWrt patch 380-disable-ctrl-iface-mib.patch
+# leads to the MIB only being compiled in if
+# CONFIG_CTRL_IFACE_MIB is enabled.
+#CONFIG_CTRL_IFACE_MIB=y

--- a/package/network/services/hostapd/files/wpa_supplicant-p2p.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-p2p.config
@@ -618,3 +618,8 @@ CONFIG_IBSS_RSN=y
 # Services can connect to the bus and provide methods
 # that can be called by other services or clients.
 CONFIG_UBUS=y
+
+# OpenWrt patch 380-disable-ctrl-iface-mib.patch
+# leads to the MIB only being compiled in if
+# CONFIG_CTRL_IFACE_MIB is enabled.
+#CONFIG_CTRL_IFACE_MIB=y


### PR DESCRIPTION
This enables the CTRL_IFACE_MIB symbol for wpad-full and hostapd-full.
If it is not enabled, statistic outputs such as "hostapd_cli all_sta"
are empty.

Signed-off-by: David Bauer <mail@david-bauer.net>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
